### PR TITLE
App names are now full bundles

### DIFF
--- a/.e2e-test/shared/app-data.js
+++ b/.e2e-test/shared/app-data.js
@@ -18,31 +18,27 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 module.exports = {
     app1: {
-        app: 'app1',
-        version: '1',
+        app: 'app1-1.tar.bz2',
         contents: {
             'index.html': '3bfa3e40f142c9e6143eab5a9a13bbe5'
         }
     },
     app2: {
-        app: 'app2',
-        version: '1.0.1',
+        app: 'app2-1.0.1.tar.bz2',
         contents: {
             'index.html': 'f6bf0230e47135a8245be5a8e49e765f',
             'roquefabio-unsplash.jpg': '3ea45b9bdc5bd2a856df0af23da867cf'
         }
     },
     app2v2: {
-        app: 'app2',
-        version: '1.2.0',
+        app: 'app2-1.2.0.tar.bz2',
         contents: {
             'index.html': 'c457a60869554676811f3b0a183aeca6',
             'roquefabio-unsplash.jpg': '3ea45b9bdc5bd2a856df0af23da867cf'
         }
     },
     app3: {
-        app: 'app3',
-        version: '502',
+        app: 'app3-502.tar.bz2',
         contents: {
             '403.html': 'e9f3ffd6f02ff6485585745aeda1f651',
             '404.html': 'dc39a4bece6c7c794063c716af8102c0',

--- a/.e2e-test/shared/sites-data.js
+++ b/.e2e-test/shared/sites-data.js
@@ -74,14 +74,12 @@ const sitesData = {
 sitesData.site2app2 = cloneObject(sitesData.site2)
 sitesData.site2app2.app = {
     name: appData.app2.app,
-    version: appData.app2.version
 }
 
 // site3 with app3 deployed
 sitesData.site3app3 = cloneObject(sitesData.site3)
 sitesData.site3app3.app = {
     name: appData.app3.app,
-    version: appData.app3.version
 }
 
 // Patch requests for site1

--- a/.e2e-test/suite/04-manage.test.js
+++ b/.e2e-test/suite/04-manage.test.js
@@ -278,7 +278,6 @@ describe('Manage sites', function() {
         // Request
         const app = {
             name: appData.app1.app,
-            version: appData.app1.version,
         }
         const response = await shared.nodeRequest
             .put('/site/site1.local/app')

--- a/api/routes/deploy.go
+++ b/api/routes/deploy.go
@@ -53,6 +53,12 @@ func DeploySiteHandler(c *gin.Context) {
 		})
 		return
 	}
+	if !app.Validate() {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid app name",
+		})
+		return
+	}
 
 	site.App = &app
 

--- a/api/routes/uploadauth.go
+++ b/api/routes/uploadauth.go
@@ -59,9 +59,9 @@ func UploadAuthHandler(c *gin.Context) {
 		})
 		return
 	}
-	if app.Name == "" || app.Version == "" {
+	if app.Name == "" {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-			"error": "'name' and 'version' fields must not be empty",
+			"error": "'name' fields must not be empty",
 		})
 		return
 	}
@@ -83,8 +83,7 @@ func UploadAuthHandler(c *gin.Context) {
 	}
 
 	// Ensure that the blob doesn't exist already
-	archiveName := app.Name + "-" + app.Version + ".tar.bz2"
-	archiveURL := fmt.Sprintf("https://%s.blob.%s/%s/%s", azureStorageAccount, azureStorageSuffix, azureStorageContainer, archiveName)
+	archiveURL := fmt.Sprintf("https://%s.blob.%s/%s/%s", azureStorageAccount, azureStorageSuffix, azureStorageContainer, app.Name)
 	u, err := url.Parse(archiveURL)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -175,7 +174,7 @@ func UploadAuthHandler(c *gin.Context) {
 	// Generate the SAS URL
 	// Reference: https://docs.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#construct-a-user-delegation-sas
 	// .NET Implementation: https://github.com/Azure/azure-sdk-for-net/blob/20985657349e7baab94fabba344120aa32483943/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs#L266
-	canonicalizedResource := fmt.Sprintf("/blob/%s/%s/%s", azureStorageAccount, azureStorageContainer, archiveName)
+	canonicalizedResource := fmt.Sprintf("/blob/%s/%s/%s", azureStorageAccount, azureStorageContainer, app.Name)
 	stringToSign := strings.Join([]string{
 		"rw",                   // signedPermissions: Read and Write
 		timeStart,              // signedStart

--- a/appmanager/appmanager.go
+++ b/appmanager/appmanager.go
@@ -233,7 +233,7 @@ func (m *Manager) SyncSiteFolders(sites []state.SiteState) (bool, error) {
 		// www is always a symbolic link, and if there's no app deployed, it goes to the default one
 		bundle := "_default"
 		if s.App != nil {
-			bundle = s.App.Name + "-" + s.App.Version
+			bundle = s.App.Name
 		}
 		if err := m.ActivateApp(bundle, s.Domain); err != nil {
 			m.log.Println("Error while activating app for site:", s.Domain, err)
@@ -311,29 +311,28 @@ func (m *Manager) SyncApps(sites []state.SiteState) error {
 		}
 
 		// Check if we have the app deployed
-		folderName := s.App.Name + "-" + s.App.Version
-		exists, err := utils.PathExists(m.appRoot + "apps/" + folderName)
+		exists, err := utils.PathExists(m.appRoot + "apps/" + s.App.Name)
 		if err != nil {
 			return err
 		}
 		if !exists {
-			m.log.Println("Need to fetch", folderName)
+			m.log.Println("Need to fetch", s.App.Name)
 
 			// Do not fetch this app if it's already being fetched
-			if _, ok := fetchAppsList[folderName]; ok {
-				m.log.Println("App", folderName, "is already being fetched")
+			if _, ok := fetchAppsList[s.App.Name]; ok {
+				m.log.Println("App", s.App.Name, "is already being fetched")
 			} else {
 				// We need to deploy the app
 				// Use the worker pool to handle concurrency
-				fetchAppsList[folderName] = 1
+				fetchAppsList[s.App.Name] = 1
 				jobs <- s
 				requested++
 			}
 		}
 
 		// Add app to expected list and the index to the dictionary
-		expectApps = append(expectApps, folderName)
-		appIndexes[folderName] = i
+		expectApps = append(expectApps, s.App.Name)
+		appIndexes[s.App.Name] = i
 	}
 
 	// No more jobs; close the channel
@@ -619,29 +618,29 @@ func (m *Manager) LoadSigningKey() error {
 }
 
 // StageApp stages an app after unpacking the bundle
-func (m *Manager) StageApp(app string, version string) error {
+func (m *Manager) StageApp(bundle string) error {
 	// Check if the app has been staged already
-	stagingPath := m.appRoot + "apps/" + app + "-" + version
+	stagingPath := m.appRoot + "apps/" + bundle
 	exists, err := utils.PathExists(stagingPath)
 	if err != nil {
 		return err
 	}
 	if exists {
 		// All done, we can just exit
-		m.log.Println("App already staged: " + app + "-" + version)
+		m.log.Println("App already staged: " + bundle)
 		return nil
 	}
 
 	// Check if we need to download the bundle
-	archivePath := m.appRoot + "cache/" + app + "-" + version + ".tar.bz2"
+	archivePath := m.appRoot + "cache/" + bundle
 	exists, err = utils.PathExists(archivePath)
 	if err != nil {
 		return err
 	}
 	if !exists {
 		// Bundle doesn't exist, so we need to download it
-		m.log.Println("Fetching bundle: " + app + "-" + version)
-		if err := m.FetchBundle(app, version); err != nil {
+		m.log.Println("Fetching bundle: " + bundle)
+		if err := m.FetchBundle(bundle); err != nil {
 			return err
 		}
 	}
@@ -660,7 +659,7 @@ func (m *Manager) StageApp(app string, version string) error {
 	if err != nil {
 		return err
 	}
-	err = utils.ExtractArchive(stagingPath, f, stat.Size(), utils.ArchiveTarBz2)
+	err = utils.ExtractArchive(stagingPath, f, stat.Size(), utils.ArchiveTypeByExtension(bundle))
 	if err != nil {
 		return err
 	}
@@ -671,13 +670,13 @@ func (m *Manager) StageApp(app string, version string) error {
 // Background worker for the StageApp function
 func (m *Manager) workerStageApp(id int, jobs <-chan state.SiteState, res chan<- int) {
 	for j := range jobs {
-		m.log.Println("Worker", id, "started staging app "+j.App.Name+"-"+j.App.Version)
-		err := m.StageApp(j.App.Name, j.App.Version)
-		m.log.Println("Worker", id, "finished staging app "+j.App.Name+"-"+j.App.Version)
+		m.log.Println("Worker", id, "started staging app "+j.App.Name)
+		err := m.StageApp(j.App.Name)
+		m.log.Println("Worker", id, "finished staging app "+j.App.Name)
 
 		// Handle errors
 		if err != nil {
-			m.log.Println("Error staging app "+j.App.Name+"-"+j.App.Version+":", err)
+			m.log.Println("Error staging app "+j.App.Name+":", err)
 
 			// Store the error
 			state.Instance.SetSiteHealth(j.Domain, err)
@@ -686,12 +685,10 @@ func (m *Manager) workerStageApp(id int, jobs <-chan state.SiteState, res chan<-
 	}
 }
 
-// FetchBundle downloads the application's tar.bz2 bundle for a specific version
-func (m *Manager) FetchBundle(bundle string, version string) error {
-	archiveName := bundle + "-" + version + ".tar.bz2"
-
+// FetchBundle downloads the application's bundle
+func (m *Manager) FetchBundle(bundle string) error {
 	// Get the archive
-	u, err := url.Parse(m.azureStorageURL + archiveName)
+	u, err := url.Parse(m.azureStorageURL + bundle)
 	if err != nil {
 		return err
 	}
@@ -699,9 +696,9 @@ func (m *Manager) FetchBundle(bundle string, version string) error {
 	resp, err := blobURL.Download(context.TODO(), 0, azblob.CountToEnd, azblob.BlobAccessConditions{}, false)
 	if err != nil {
 		if stgErr, ok := err.(azblob.StorageError); !ok {
-			err = fmt.Errorf("Network error while downloading the archive: %s", err.Error())
+			err = fmt.Errorf("Network error while downloading the bundle: %s", err.Error())
 		} else {
-			err = fmt.Errorf("Azure Storage error while downloading the archive: %s", stgErr.Response().Status)
+			err = fmt.Errorf("Azure Storage error while downloading the bundle: %s", stgErr.Response().Status)
 		}
 		return err
 	}
@@ -734,7 +731,7 @@ func (m *Manager) FetchBundle(bundle string, version string) error {
 	tee := io.TeeReader(body, h)
 
 	// Write to disk (this also makes the stream proceed so the hash is calculated)
-	out, err := os.Create(m.appRoot + "cache/" + archiveName)
+	out, err := os.Create(m.appRoot + "cache/" + bundle)
 	if err != nil {
 		return err
 	}
@@ -745,8 +742,8 @@ func (m *Manager) FetchBundle(bundle string, version string) error {
 		out.Close()
 
 		if *deleteFile {
-			m.log.Println("Deleting archive " + archiveName)
-			os.Remove(m.appRoot + "cache/" + archiveName)
+			m.log.Println("Deleting bundle " + bundle)
+			os.Remove(m.appRoot + "cache/" + bundle)
 		}
 	}(&deleteFile)
 
@@ -765,7 +762,7 @@ func (m *Manager) FetchBundle(bundle string, version string) error {
 		// (Need to grab the first 512 bytes from the signature only)
 		err = rsa.VerifyPKCS1v15(m.codeSignKey, crypto.SHA256, hashed, signature[:512])
 		if err != nil {
-			m.log.Printf("Signature mismatch for bundle %s-%s\n", bundle, version)
+			m.log.Println("Signature mismatch for bundle", bundle)
 
 			// File needs to be deleted if signature is invalid
 			deleteFile = true
@@ -773,7 +770,7 @@ func (m *Manager) FetchBundle(bundle string, version string) error {
 			return err
 		}
 	} else {
-		m.log.Printf("WARN Bundle %s-%s did not contain a signature; skipping integrity and origin check\n", bundle, version)
+		m.log.Printf("WARN Bundle %s did not contain a signature; skipping integrity and origin check\n", bundle)
 	}
 
 	return nil

--- a/appmanager/appmanager.go
+++ b/appmanager/appmanager.go
@@ -664,6 +664,32 @@ func (m *Manager) StageApp(bundle string) error {
 		return err
 	}
 
+	// Check how many filles were extracted
+	contents, err := ioutil.ReadDir(stagingPath)
+	if err != nil {
+		return err
+	}
+	if len(contents) == 0 {
+		// If there's nothing in the extracted bundle, remove the folder and return an error
+		if err := os.Remove(stagingPath); err != nil {
+			return err
+		}
+		return errors.New("no files in the extracted folder")
+	} else if len(contents) == 1 && contents[0].IsDir() && false {
+		// If there's only one folder, move all files one directory up
+		// First, rename to a temporary folder (app bundles can't begin with an underscore)
+		// Then, delete the target folder and rename the extracted one
+		if err := os.Rename(stagingPath+"/"+contents[0].Name(), m.appRoot+"apps/__"+bundle); err != nil {
+			return err
+		}
+		if err := os.Remove(stagingPath); err != nil {
+			return err
+		}
+		if err := os.Rename(m.appRoot+"apps/__"+bundle, stagingPath); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/state/types.go
+++ b/state/types.go
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package state
 
 import (
+	"strings"
 	"time"
 
 	"github.com/statiko-dev/statiko/utils"
@@ -58,11 +59,29 @@ type SiteTLS struct {
 // SiteApp represents the state of an app deployed or being deployed
 type SiteApp struct {
 	// App details
-	Name    string `json:"name" binding:"required"`
-	Version string `json:"version" binding:"required"`
+	Name string `json:"name" binding:"required"`
 
 	// App manifest (for internal use)
 	Manifest *utils.AppManifest `json:"-"`
+}
+
+// Validate returns true if the app object is valid
+func (a *SiteApp) Validate() bool {
+	// Name must be at least 4 characters (it must include an extension)
+	// Also, Name must not start with `_`
+	if len(a.Name) < 4 || a.Name[0] == '_' {
+		return false
+	}
+
+	// Ensure that there's an extension, of a supported type
+	nameLc := strings.ToLower(a.Name)
+	for _, ext := range utils.ArchiveExtensions {
+		if strings.HasSuffix(nameLc, ext) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // NodeDHParams represents the DH Parameters file (PEM-encoded) and their age

--- a/statuscheck/statuscheck.go
+++ b/statuscheck/statuscheck.go
@@ -186,8 +186,7 @@ func updateHealthCache() (hasError bool) {
 		if siteErr := state.Instance.GetSiteHealth(s.Domain); siteErr != nil {
 			var appStr *string
 			if s.App != nil {
-				str := s.App.Name + "-" + s.App.Version
-				appStr = &str
+				appStr = &s.App.Name
 			}
 			healthCache = append(healthCache, utils.SiteHealth{
 				Domain: s.Domain,
@@ -209,7 +208,7 @@ func updateHealthCache() (hasError bool) {
 			// Start the request in parallel
 			jobs <- healthcheckJob{
 				domain: s.Domain,
-				bundle: s.App.Name + "-" + s.App.Version,
+				bundle: s.App.Name,
 			}
 			requested++
 		} else {

--- a/utils/archive.go
+++ b/utils/archive.go
@@ -41,9 +41,41 @@ const (
 	ArchiveRar
 )
 
+// Valid extensions
+var ArchiveExtensions = []string{".zip", ".tar", ".tar.bz2", ".tbz2", ".tar.gz", ".tgz", ".tar.lz4", ".tlz4", ".tar.sz", ".tsz", ".tar.xz", ".txz", ".rar"}
+
 // Used as interface
 type archiveHeader struct {
 	Name string
+}
+
+// ArchiveTypeByExtension returns the type of the archive by the file's extension
+// Note: this function assumes that the file was already validated to contain one of the valid extensions
+// Ensure to use the SiteApp.Validate() method first
+func ArchiveTypeByExtension(name string) int {
+	// Get the last 4 characters
+	// This is safe since we know the extension is one of those in the list
+	name = strings.ToLower(name)
+	switch name[len(name)-4:] {
+	case ".tar":
+		return ArchiveTar
+	case ".bz2", "tbz2":
+		return ArchiveTarBz2
+	case "r.gz", ".tgz":
+		return ArchiveTarGz
+	case ".lz4", "tlz4":
+		return ArchiveTarLz4
+	case "r.sz", ".tsz":
+		return ArchiveTarSz
+	case "r.xz", ".txz":
+		return ArchiveTarXz
+	case ".zip":
+		return ArchiveZip
+	case ".rar":
+		return ArchiveRar
+	}
+
+	return -1
 }
 
 // ExtractArchive extracts a compressed archive

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -112,7 +112,7 @@ func FolderExists(path string) (bool, error) {
 
 // EnsureFolder creates a folder if it doesn't exist already
 func EnsureFolder(path string) error {
-	exists, err := PathExists(path)
+	exists, err := FolderExists(path)
 	if err != nil {
 		return err
 	} else if !exists {

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -30,6 +30,8 @@ import (
 	"math/big"
 	"math/rand"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/statiko-dev/statiko/appconfig"
 )
@@ -146,4 +148,21 @@ func NodeAddress() string {
 		address = appconfig.Config.GetString("nodeName")
 	}
 	return address
+}
+
+var appNameRegEx *regexp.Regexp
+
+// SanitizeAppName validates and sanitizes the name of an app's bundle
+// App bundles must be lowercase strings containing letters, numbers, dashes and dots. The first character must be a letter, and they must contain a supported extension
+func SanitizeAppName(name string) string {
+	if appNameRegEx == nil {
+		extensions := strings.ReplaceAll(strings.Join(ArchiveExtensions, "|"), ".", "\\.")
+		appNameRegEx = regexp.MustCompile("^([a-z][a-zA-Z0-9\\.\\-]*)(" + extensions + ")$")
+	}
+	name = strings.ToLower(name)
+	if !appNameRegEx.MatchString(name) {
+		name = ""
+	}
+
+	return name
 }


### PR DESCRIPTION
Changed the way apps are referenced. Rather than having an app name and a version, compressed as tar.bz2, we are now using a single `name` field which points to a specific bundle in the storage.

Additionally:

1. Supports bundles in other formats, such as zip, tar.gz, and a bunch more
2. If the bundle contains all files inside a single sub-folder, move the files one level up

This introduces a new format for the state object that is not backwards-compatible. It requires updates to stkcli too.